### PR TITLE
Feat / improve vertical scroll block and add swipe/slide callbacks

### DIFF
--- a/src/TileSlider/TileSlider.tsx
+++ b/src/TileSlider/TileSlider.tsx
@@ -169,7 +169,7 @@ const TileSlider = <T extends unknown>({
     [animated, cycleMode, index, items.length, tileWidth, tilesToShow],
   );
 
-  const verticalScrollBlockedRef = useRef<boolean>();
+  const verticalScrollBlockedRef = useRef(false);
 
   const handleTouchStart = useCallback(
     (event: React.TouchEvent): void => {
@@ -190,7 +190,7 @@ const TileSlider = <T extends unknown>({
           event.preventDefault();
           event.stopPropagation();
 
-          if (verticalScrollBlockedRef.current) verticalScrollBlockedRef.current = true;
+          verticalScrollBlockedRef.current = true;
           if (onSwipeStart) onSwipeStart();
         }
       }
@@ -221,7 +221,7 @@ const TileSlider = <T extends unknown>({
         document.removeEventListener('touchend', handleTouchEnd);
         document.removeEventListener('touchcancel', handleTouchCancel);
 
-        if (verticalScrollBlockedRef.current) verticalScrollBlockedRef.current = false;
+        verticalScrollBlockedRef.current = false;
         if (onSwipeEnd) onSwipeEnd();
       }
 
@@ -258,7 +258,7 @@ const TileSlider = <T extends unknown>({
     };
 
     if (doAnimationReset) resetAnimation();
-  }, [doAnimationReset, index, items.length, slideToIndex, tileWidth, tilesToShow, transitionBasis]);
+  }, [doAnimationReset, index, items.length, slideToIndex, tileWidth, tilesToShow, transitionBasis, onSlideEnd]);
 
   const handleTransitionEnd = (event: React.TransitionEvent<HTMLUListElement>) => {
     if (event.target === frameRef.current) {


### PR DESCRIPTION
This PR improves vertical scroll blocking and adds swipe/slide callbacks:
- Whenever vertical scroll gets blocked, it gets stored into a ref, so that it won't undo the block until the touch is let go. 
- Also, some callbacks are called (`onSwipeStart`, `onSwipeEnd`), to be used to block vertical scrolling on the body for example. 
- Another callback `onSlideEnd` gets called to help implementations control the focus after the slide animation.