### PR TITLE
Chore / add .css import requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ npm install @videodock/tile-slider
 
 This section will be extended. For now, please see the below example which uses all the supported features.
 
+#### Important: .css file import requirement (version 1.0.1 and above)
+Starting from version `1.0.1`, it's crucial to include the `.css` import explicitly, as demonstrated in the example below:
+
 ```tsx
 import { TileSlider, CYCLE_MODE_RESTART } from '@videodock/tile-slider';
 import '@videodock/tile-slider/TileSlider.css';


### PR DESCRIPTION
## This PR

- **CSS Import Requirement:** It's now emphasised in the `README` that starting from version `v1.0.1`, it's necessary to include the `.css` import explicitly for proper styling and functionality of the TileSlider component