### PR TITLE
Feat / Swipe optimisation (mobile)

### DIFF
--- a/docs/docs/examples-advanced/responsive-slider.mdx
+++ b/docs/docs/examples-advanced/responsive-slider.mdx
@@ -10,7 +10,6 @@ The `useResponsiveSize` hook is optimized and only re-renders when the current b
 
 ## Example
 
-
 import { ResponsiveSlider } from './advanced-examples';
 
 <ResponsiveSlider />
@@ -21,7 +20,7 @@ import { ResponsiveSlider } from './advanced-examples';
 import { TileSlider, useResponsiveSize } from '@videodock/tile-slider';
 
 const Slider = () => {
-  const [tilesToShow] = useResponsiveSize([{ xs: 1, sm: 2, md: 3, lg: 4, xl: 5 }]);
+  const [tilesToShow] = useResponsiveSize([{ xs: 2, sm: 2, md: 3, lg: 4, xl: 5 }]);
 
   return (
     <TileSlider

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -13,8 +13,8 @@ export const CYCLE_MODE_ENDLESS = 'endless';
 export const PREFERS_REDUCED_MOTION = typeof window !== 'undefined' ? !window.matchMedia('(prefers-reduced-motion)').matches : false;
 
 const DRAG_EDGE_SNAP = 50;
-const VELOCITY_SPEED = 10;
-const SNAPPING_DAMPING = 300;
+const VELOCITY_SPEED = 50;
+const SNAPPING_DAMPING = 2000;
 
 export type Direction = 'left' | 'right';
 export type CycleMode = 'stop' | 'restart' | 'endless';

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -204,7 +204,7 @@ export const TileSlider = <T,>({
     const velocityTargetPosition = startPosition + startVelocity * VELOCITY_SPEED;
 
     const tileWidth = frameRef.current.offsetWidth / tilesToShow;
-    const targetIndex = Math.round((velocityTargetPosition / tileWidth) * -1);
+    const targetIndex = Math[startVelocity > 0 ? 'floor' : 'ceil']((velocityTargetPosition / tileWidth) * -1);
 
     handleSnapping(targetIndex, easeOut);
   });

--- a/src/utils/easing.ts
+++ b/src/utils/easing.ts
@@ -6,6 +6,12 @@ export const easeOut: AnimationFn = (currentTime, startValue, changeInValue, dur
   return changeInValue * (currentTime * currentTime * currentTime + 1) + startValue;
 };
 
+export const easeOutQuartic: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
+  currentTime /= duration;
+  currentTime--;
+  return -changeInValue * (currentTime * currentTime * currentTime * currentTime - 1) + startValue;
+};
+
 export const easeInOut: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
   currentTime /= duration / 2;
   if (currentTime < 1) {


### PR DESCRIPTION
This PR suggests a few optimisation tweaks for mobile swiping: 
- Much higher velocity and damping values, for a more native feel (_note: As a result, the slideToIndex function is too slow, needs an update)_ 
- Only snap in sliding direction. This prevents snapping backwards, which feels counter-intuitive
- Depend the duration on the momentum, so that longer distances have a bit more time to slow down. I feel this greatly improves the native feel of it.
- Adds a heavier curve, `easeOutQuartic`, so that slowing down locks better into the snapping

Some other great potential improvements, still to be done:
- Lock all movements once the user touches the screen again. I've tried implementing this, but couldn't get it stable
- Block slide while scrolling the page (inversion of blocking page scroll while sliding)
- Make all tiles opaque during slide
