### PR TITLE
Fix / layout shift when controls are focussed on android talkback

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -18,8 +18,8 @@
 }
 
 .TileSlider-leftControl {
-    left: 0;
     position: absolute;
+    left: 1px; /* Fixes layout shifting issues when focussed on Android Talkback */
     top: 50%;
     transform: translateY(-100%);
     z-index: 1;
@@ -27,7 +27,7 @@
 
 .TileSlider-rightControl {
     position: absolute;
-    right: 0;
+    right: 1px;  /* Fixes layout shifting issues when focussed on Android Talkback */
     top: 50%;
     transform: translateY(-100%);
 }


### PR DESCRIPTION
We need a gap of at least 1px so the screen reader focus outline doesn't corrupt the layout when these elements get focussed. This only happens on the Android screen reader (TalkBack).

Related PR: https://github.com/Videodock/ott-web-app/pull/123

Ticket: https://videodock.atlassian.net/browse/OTT-1305