### PR TITLE
Feat / swipe optimizations, features and fixes

### DIFF
--- a/docs/docs/examples-advanced/responsive-slider.mdx
+++ b/docs/docs/examples-advanced/responsive-slider.mdx
@@ -10,7 +10,6 @@ The `useResponsiveSize` hook is optimized and only re-renders when the current b
 
 ## Example
 
-
 import { ResponsiveSlider } from './advanced-examples';
 
 <ResponsiveSlider />
@@ -21,7 +20,7 @@ import { ResponsiveSlider } from './advanced-examples';
 import { TileSlider, useResponsiveSize } from '@videodock/tile-slider';
 
 const Slider = () => {
-  const [tilesToShow] = useResponsiveSize([{ xs: 1, sm: 2, md: 3, lg: 4, xl: 5 }]);
+  const [tilesToShow] = useResponsiveSize([{ xs: 2, sm: 2, md: 3, lg: 4, xl: 5 }]);
 
   return (
     <TileSlider

--- a/docs/docs/examples-advanced/with-ref.mdx
+++ b/docs/docs/examples-advanced/with-ref.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 5
+---
+
+# With ref
+
+## Example
+
+import { WithRefExample } from '../helpers';
+import '../../../src/style.css';
+
+<WithRefExample />
+
+## Code
+
+```tsx
+import { TileSlider, type TileSliderRef } from '@videodock/tile-slider';
+
+const Slider = () => {
+  const tileSliderRef = useRef<TileSliderRef>();
+  const [state, setState] = useState({ index: 0, itemIndex: 0, page: 0 });
+
+  return (
+    <>
+      <TileSlider
+        ref={tileSliderRef}
+        tilesToShow={3}
+        renderTile={renderTile}
+        items={items}
+        renderRightControl={renderRightControl}
+        renderLeftControl={renderLeftControl}
+        onSlideEnd={({ index, itemIndex, page }) => setState({ index, itemIndex, page })}
+      />
+      <hr />
+      <h3>State</h3>
+      <div>
+        <label>Current index:</label> {state.index}{' '}
+      </div>
+      <div>
+        <label>Current item index:</label> {state.itemIndex}{' '}
+      </div>
+      <div>
+        <label>Current page:</label> {state.page}
+      </div>
+      <h3>Controls</h3>
+      <div>
+        <strong>slide(direction: &apos;left&apos; | &apos;right&apos;)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slide('left')}>Slide left</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slide('right')}>Slide right</button>
+      </div>
+      <div>
+        <strong>slideToIndex(index: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToIndex(0)}>Slide to index: 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(10)}>Slide to index: 10</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(100)}>Slide to index: 100</button>
+        <button onClick={() => tileSliderRef.current?.slideToIndex(105, true)}>Slide to index: 105 (closest)</button>
+      </div>
+      <div>
+        <strong>slideToPage(page: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToPage(0)}>Slide to page 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToPage(3)}>Slide to page 3</button>
+      </div>
+    </>
+  );
+};
+```

--- a/docs/docs/examples/no-pages.mdx
+++ b/docs/docs/examples/no-pages.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 6
+---
+
+# No pages
+
+
+## Example
+
+import { TileSlider } from '../../../src';
+import { items, renderLeftControl, renderRightControl, renderTile } from '../helpers';
+import '../../../src/style.css';
+
+<TileSlider tilesToShow={3} renderTile={renderTile} items={items.slice(0, 3)} renderRightControl={renderRightControl} renderLeftControl={renderLeftControl} />
+
+## Code
+
+```tsx
+import { TileSlider, type RenderTile, type RenderControl } from '@videodock/tile-slider';
+
+type Tile = {
+  title: string;
+  image: string;
+};
+
+// create example data set with 10 tiles
+const items: Tile[] = Array.from({ length: 10 }, (_, index) => ({
+  title: `Tile ${index}`,
+  image: `/img/${index}.jpg`,
+}));
+
+const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
+  <div className={`exampleTile ${!isVisible ? 'outOfView' : ''}`}>
+    <img src={item.image} alt={item.title} />
+  </div>
+);
+
+const renderLeftControl: RenderControl = ({ onClick }) => (
+  <button className="control" onClick={onClick}>
+    <IconLeft />
+  </button>
+);
+
+const renderRightControl: RenderControl = ({ onClick }) => (
+  <button className="control" onClick={onClick}>
+    <IconRight />
+  </button>
+);
+
+const Slider = () => {
+  return (
+    <TileSlider
+      tilesToShow={3}
+      renderTile={renderTile}
+      items={items}
+      renderRightControl={renderRightControl}
+      renderLeftControl={renderLeftControl}
+    />
+  );
+};
+```

--- a/docs/docs/helpers.tsx
+++ b/docs/docs/helpers.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import siteConfig from '@generated/docusaurus.config';
 
-import { RenderControl, RenderPagination, RenderTile } from '../../src';
+import { RenderControl, RenderPagination, RenderTile, TileSlider, TileSliderRef } from '../../src';
 
 export type Tile = {
   title: string;
@@ -97,7 +97,6 @@ export const makeItems = (length: number): Tile[] =>
     };
   });
 
-
 export function easeOutElastic(currentTime: number, startValue: number, changeInValue: number, duration: number): number {
   if (currentTime === 0) {
     return startValue;
@@ -115,6 +114,51 @@ export function easeOutElastic(currentTime: number, startValue: number, changeIn
     startValue
   );
 }
+
+export const WithRefExample = () => {
+  const tileSliderRef = useRef<TileSliderRef>();
+  const [state, setState] = useState({ index: 0, itemIndex: 0, page: 0 });
+
+  return (
+    <>
+      <TileSlider
+        ref={tileSliderRef}
+        tilesToShow={3}
+        renderTile={renderTile}
+        items={items}
+        renderRightControl={renderRightControl}
+        renderLeftControl={renderLeftControl}
+        onSlideEnd={({ index, itemIndex, page }) => setState({ index, itemIndex, page })}
+      />
+      <hr />
+      <h3>State</h3>
+      <div><label>Current index:</label> {state.index} </div>
+      <div><label>Current item index:</label> {state.itemIndex} </div>
+      <div><label>Current page:</label> {state.page}</div>
+      <h3>Controls</h3>
+      <div>
+        <strong>slide(direction: &apos;left&apos; | &apos;right&apos;)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slide('left')}>Slide left</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slide('right')}>Slide right</button>
+      </div>
+      <div>
+        <strong>slideToIndex(index: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToIndex(0)}>Slide to index: 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(10)}>Slide to index: 10</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(100)}>Slide to index: 100</button>
+        <button onClick={() => tileSliderRef.current?.slideToIndex(105, true)}>Slide to index: 105 (closest)</button>
+      </div>
+      <div>
+        <strong>slideToPage(page: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToPage(0)}>Slide to page 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToPage(3)}>Slide to page 3</button>
+      </div>
+    </>
+  );
+};
 
 export const items = makeItems(10);
 export const moreItems = makeItems(50);

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -13,8 +13,8 @@ export const CYCLE_MODE_ENDLESS = 'endless';
 export const PREFERS_REDUCED_MOTION = typeof window !== 'undefined' ? !window.matchMedia('(prefers-reduced-motion)').matches : false;
 
 const DRAG_EDGE_SNAP = 50;
-const VELOCITY_SPEED = 10;
-const SNAPPING_DAMPING = 300;
+const VELOCITY_SPEED = 50;
+const SNAPPING_DAMPING = 2000;
 
 export type Direction = 'left' | 'right';
 export type CycleMode = 'stop' | 'restart' | 'endless';

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -204,7 +204,7 @@ export const TileSlider = <T,>({
     const velocityTargetPosition = startPosition + startVelocity * VELOCITY_SPEED;
 
     const tileWidth = frameRef.current.offsetWidth / tilesToShow;
-    const targetIndex = Math.round((velocityTargetPosition / tileWidth) * -1);
+    const targetIndex = Math[startVelocity > 0 ? 'floor' : 'ceil']((velocityTargetPosition / tileWidth) * -1);
 
     handleSnapping(targetIndex, easeOut);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { TileSlider, CYCLE_MODE_ENDLESS, CYCLE_MODE_RESTART, CYCLE_MODE_STOP } from './TileSlider';
-export type { RenderTile, RenderControl, RenderPagination, TileSliderProps } from './TileSlider';
+export type { RenderTile, RenderControl, RenderPagination, TileSliderProps, TileSliderRef } from './TileSlider';
 
 export { useResponsiveSize } from './hooks/useResponsiveSize';
 export * as easing from './utils/easing';

--- a/src/utils/drag.ts
+++ b/src/utils/drag.ts
@@ -2,7 +2,7 @@ export type Position = { x: number; y: number };
 export type TouchMoves = { position: Position; ts: number }[];
 
 export const registerMove = (lastMoves: TouchMoves, position: Position) => {
-  return [{ position, ts: Date.now() }, ...lastMoves].slice(0, 5).filter((move) => move.ts > Date.now() - 100);
+  return [{ position, ts: Date.now() }, ...lastMoves].slice(0, 5).filter((move) => move.ts > Date.now() - 250);
 };
 
 export const getVelocity = (lastMoves: TouchMoves) => {
@@ -11,5 +11,6 @@ export const getVelocity = (lastMoves: TouchMoves) => {
   const distance = lastMoves[0].position.x - lastMoves[lastMoves.length - 1].position.x;
   const time = lastMoves[0].ts - lastMoves[lastMoves.length - 1].ts;
 
-  return distance * (time / 32);
+  // velocity is movement per millisecond
+  return distance / time;
 };

--- a/src/utils/drag.ts
+++ b/src/utils/drag.ts
@@ -2,12 +2,14 @@ export type Position = { x: number; y: number };
 export type TouchMoves = { position: Position; ts: number }[];
 
 export const registerMove = (lastMoves: TouchMoves, position: Position) => {
-  return [{ position, ts: Date.now() }, ...lastMoves].slice(0, 2);
+  return [{ position, ts: Date.now() }, ...lastMoves].slice(0, 5).filter((move) => move.ts > Date.now() - 100);
 };
 
 export const getVelocity = (lastMoves: TouchMoves) => {
-  const distance = lastMoves[0]?.position.x - lastMoves[1]?.position.x;
-  const time = lastMoves[0]?.ts - lastMoves[1]?.ts;
+  if (lastMoves.length < 2) return 0;
+
+  const distance = lastMoves[0].position.x - lastMoves[lastMoves.length - 1].position.x;
+  const time = lastMoves[0].ts - lastMoves[lastMoves.length - 1].ts;
 
   return distance * (time / 32);
 };

--- a/src/utils/easing.ts
+++ b/src/utils/easing.ts
@@ -12,6 +12,11 @@ export const easeOutQuartic: AnimationFn = (currentTime, startValue, changeInVal
   return -changeInValue * (currentTime * currentTime * currentTime * currentTime - 1) + startValue;
 };
 
+export const easeInOutCubic: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
+  currentTime /= duration;
+  return changeInValue * (currentTime < 0.5 ? 4 * currentTime * currentTime * currentTime : 1 - Math.pow(-2 * currentTime + 2, 3) / 2) + startValue;
+}
+
 export const easeInOut: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
   currentTime /= duration / 2;
   if (currentTime < 1) {

--- a/src/utils/easing.ts
+++ b/src/utils/easing.ts
@@ -6,6 +6,12 @@ export const easeOut: AnimationFn = (currentTime, startValue, changeInValue, dur
   return changeInValue * (currentTime * currentTime * currentTime + 1) + startValue;
 };
 
+export const easeOutQuartic: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
+  currentTime /= duration;
+  currentTime--;
+  return -changeInValue * (currentTime * currentTime * currentTime * currentTime - 1) + startValue;
+};
+
 export const easeInOut: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
   currentTime /= duration / 2;
   if (currentTime < 1) {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,1 +1,5 @@
 export const getCircularIndex = (index: number, length: number) => ((index % length) + length) % length;
+
+export function interpolate(a: number, b: number, t: number): number {
+  return a * (1 - t) + b * t;
+}


### PR DESCRIPTION
This PR is based on #47 with some additional improvements and features.

The main problem with the transition between the swipe velocity and animation is that the speed needs to correspond with the swipe speed. In other words, if a user swipes with a velocity of 5 pixels per frame, it should animate from 5 pixels per frame to zero.

Before, we calculated the approximate end index and animated it to that index. This caused the starting speed to mismatch with the swipe speed, which didn't feel right.

I also added two new features:

- Control the slider using a ref (currently exposing the `slide`, `slideToIndex`, and `slideToPage` methods)
- Add `closest?: boolean` argument to the `slideToIndex` function. Instead of sliding to the absolute index, it slides to the closest circular item index

This PR also fixes a problem when there are no pages; the slider still animates, and the slide shows empty tiles or no tiles at all. Sliding is completely disabled no when there are no pages.

**Update**

I've just pushed an update with some improvements:

- Interpolate the velocity and target position to get a less bumpy snapping (I want to push this further, but it feels already a lot better now)
- Use the actual index when cancelling a touch gesture (snap to closest)
- Use the actual index when swiping to account for current swipe distance

See https://66297348da698259008b816b--tile-slider-v2.netlify.app/