### PR TITLE
Feat / iOS swipe optimization v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Performant and accessible React slider with virtualization.
 `@videodock/tile-slider` is a React component of a performant and accessible slider written in React.
 It only renders the visible tiles, meaning that you can have thousands of items and still get a good performance.
 
-TileSlider is fully written using React and doesn't have dependencies. 
+TileSlider is fully written using React and doesn't have dependencies.
 
 ## Documentation
 
@@ -25,7 +25,7 @@ Using v1, see the [v1 branch](https://github.com/Videodock/tile-slider/tree/v1).
 - Custom slide transition
 - Fully responsive using CSS
 - Accessible
-- First-class TypeScript support 
+- First-class TypeScript support
 
 ## Requirements
 
@@ -34,7 +34,7 @@ Using v1, see the [v1 branch](https://github.com/Videodock/tile-slider/tree/v1).
 
 ## Installation
 
-Install this package via (P)NPM or Yarn: 
+Install this package via (P)NPM or Yarn:
 
 ```shell
 $ yarn add @videodock/tile-slider
@@ -45,7 +45,8 @@ $ pnpm install @videodock/tile-slider
 ## Example usage
 
 > Important: .css file import requirement (version 1.0.1 and above)
-> Starting from version `1.0.1`, it's crucial to include the `.css` import explicitly, as demonstrated in the example below:
+> Starting from version `1.0.1`, it's crucial to include the `.css` import explicitly, as demonstrated in the example
+> below:
 
 ```tsx
 import { TileSlider, CYCLE_MODE_RESTART } from '@videodock/tile-slider';
@@ -98,4 +99,10 @@ Run the documentation app, which showcases all features of the TileSlider packag
 cd docs
 yarn
 yarn start
+```
+
+You can use the `--host 0.0.0.0` argument to make the dev server available on your local network:
+
+```shell
+yarn start --host 0.0.0.0
 ```

--- a/docs/docs/examples-advanced/responsive-slider.mdx
+++ b/docs/docs/examples-advanced/responsive-slider.mdx
@@ -10,7 +10,6 @@ The `useResponsiveSize` hook is optimized and only re-renders when the current b
 
 ## Example
 
-
 import { ResponsiveSlider } from './advanced-examples';
 
 <ResponsiveSlider />
@@ -21,7 +20,7 @@ import { ResponsiveSlider } from './advanced-examples';
 import { TileSlider, useResponsiveSize } from '@videodock/tile-slider';
 
 const Slider = () => {
-  const [tilesToShow] = useResponsiveSize([{ xs: 1, sm: 2, md: 3, lg: 4, xl: 5 }]);
+  const [tilesToShow] = useResponsiveSize([{ xs: 2, sm: 2, md: 3, lg: 4, xl: 5 }]);
 
   return (
     <TileSlider

--- a/docs/docs/examples-advanced/with-ref.mdx
+++ b/docs/docs/examples-advanced/with-ref.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 5
+---
+
+# With ref
+
+## Example
+
+import { WithRefExample } from '../helpers';
+import '../../../src/style.css';
+
+<WithRefExample />
+
+## Code
+
+```tsx
+import { TileSlider, type TileSliderRef } from '@videodock/tile-slider';
+
+const Slider = () => {
+  const tileSliderRef = useRef<TileSliderRef>();
+  const [state, setState] = useState({ index: 0, itemIndex: 0, page: 0 });
+
+  return (
+    <>
+      <TileSlider
+        ref={tileSliderRef}
+        tilesToShow={3}
+        renderTile={renderTile}
+        items={items}
+        renderRightControl={renderRightControl}
+        renderLeftControl={renderLeftControl}
+        onSlideEnd={({ index, itemIndex, page }) => setState({ index, itemIndex, page })}
+      />
+      <hr />
+      <h3>State</h3>
+      <div>
+        <label>Current index:</label> {state.index}{' '}
+      </div>
+      <div>
+        <label>Current item index:</label> {state.itemIndex}{' '}
+      </div>
+      <div>
+        <label>Current page:</label> {state.page}
+      </div>
+      <h3>Controls</h3>
+      <div>
+        <strong>slide(direction: &apos;left&apos; | &apos;right&apos;)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slide('left')}>Slide left</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slide('right')}>Slide right</button>
+      </div>
+      <div>
+        <strong>slideToIndex(index: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToIndex(0)}>Slide to index: 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(10)}>Slide to index: 10</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(100)}>Slide to index: 100</button>
+        <button onClick={() => tileSliderRef.current?.slideToIndex(105, true)}>Slide to index: 105 (closest)</button>
+      </div>
+      <div>
+        <strong>slideToPage(page: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToPage(0)}>Slide to page 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToPage(3)}>Slide to page 3</button>
+      </div>
+    </>
+  );
+};
+```

--- a/docs/docs/examples/no-pages.mdx
+++ b/docs/docs/examples/no-pages.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 6
+---
+
+# No pages
+
+
+## Example
+
+import { TileSlider } from '../../../src';
+import { items, renderLeftControl, renderRightControl, renderTile } from '../helpers';
+import '../../../src/style.css';
+
+<TileSlider tilesToShow={3} renderTile={renderTile} items={items.slice(0, 3)} renderRightControl={renderRightControl} renderLeftControl={renderLeftControl} />
+
+## Code
+
+```tsx
+import { TileSlider, type RenderTile, type RenderControl } from '@videodock/tile-slider';
+
+type Tile = {
+  title: string;
+  image: string;
+};
+
+// create example data set with 10 tiles
+const items: Tile[] = Array.from({ length: 10 }, (_, index) => ({
+  title: `Tile ${index}`,
+  image: `/img/${index}.jpg`,
+}));
+
+const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
+  <div className={`exampleTile ${!isVisible ? 'outOfView' : ''}`}>
+    <img src={item.image} alt={item.title} />
+  </div>
+);
+
+const renderLeftControl: RenderControl = ({ onClick }) => (
+  <button className="control" onClick={onClick}>
+    <IconLeft />
+  </button>
+);
+
+const renderRightControl: RenderControl = ({ onClick }) => (
+  <button className="control" onClick={onClick}>
+    <IconRight />
+  </button>
+);
+
+const Slider = () => {
+  return (
+    <TileSlider
+      tilesToShow={3}
+      renderTile={renderTile}
+      items={items}
+      renderRightControl={renderRightControl}
+      renderLeftControl={renderLeftControl}
+    />
+  );
+};
+```

--- a/docs/docs/helpers.tsx
+++ b/docs/docs/helpers.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import siteConfig from '@generated/docusaurus.config';
 
-import { RenderControl, RenderPagination, RenderTile } from '../../src';
+import { RenderControl, RenderPagination, RenderTile, TileSlider, TileSliderRef } from '../../src';
 
 export type Tile = {
   title: string;
@@ -97,7 +97,6 @@ export const makeItems = (length: number): Tile[] =>
     };
   });
 
-
 export function easeOutElastic(currentTime: number, startValue: number, changeInValue: number, duration: number): number {
   if (currentTime === 0) {
     return startValue;
@@ -115,6 +114,51 @@ export function easeOutElastic(currentTime: number, startValue: number, changeIn
     startValue
   );
 }
+
+export const WithRefExample = () => {
+  const tileSliderRef = useRef<TileSliderRef>();
+  const [state, setState] = useState({ index: 0, itemIndex: 0, page: 0 });
+
+  return (
+    <>
+      <TileSlider
+        ref={tileSliderRef}
+        tilesToShow={3}
+        renderTile={renderTile}
+        items={items}
+        renderRightControl={renderRightControl}
+        renderLeftControl={renderLeftControl}
+        onSlideEnd={({ index, itemIndex, page }) => setState({ index, itemIndex, page })}
+      />
+      <hr />
+      <h3>State</h3>
+      <div><label>Current index:</label> {state.index} </div>
+      <div><label>Current item index:</label> {state.itemIndex} </div>
+      <div><label>Current page:</label> {state.page}</div>
+      <h3>Controls</h3>
+      <div>
+        <strong>slide(direction: &apos;left&apos; | &apos;right&apos;)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slide('left')}>Slide left</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slide('right')}>Slide right</button>
+      </div>
+      <div>
+        <strong>slideToIndex(index: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToIndex(0)}>Slide to index: 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(10)}>Slide to index: 10</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToIndex(100)}>Slide to index: 100</button>
+        <button onClick={() => tileSliderRef.current?.slideToIndex(105, true)}>Slide to index: 105 (closest)</button>
+      </div>
+      <div>
+        <strong>slideToPage(page: number)</strong>
+        <br />
+        <button onClick={() => tileSliderRef.current?.slideToPage(0)}>Slide to page 0</button>{' '}
+        <button onClick={() => tileSliderRef.current?.slideToPage(3)}>Slide to page 3</button>
+      </div>
+    </>
+  );
+};
 
 export const items = makeItems(10);
 export const moreItems = makeItems(50);

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -31,6 +31,12 @@
 
 .exampleTile {
   overflow: hidden;
+  -webkit-touch-callout: none;
+  user-select: none;
+}
+
+.TileSlider-list > li {
+  margin-top: 0 !important; /* override Docusaurus */
 }
 
 .exampleTile > img {
@@ -39,6 +45,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  -webkit-touch-callout: none;
 }
 
 .outOfView {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { TileSlider, CYCLE_MODE_ENDLESS, CYCLE_MODE_RESTART, CYCLE_MODE_STOP } from './TileSlider';
-export type { RenderTile, RenderControl, RenderPagination, TileSliderProps } from './TileSlider';
+export type { RenderTile, RenderControl, RenderPagination, TileSliderProps, TileSliderRef } from './TileSlider';
 
 export { useResponsiveSize } from './hooks/useResponsiveSize';
 export * as easing from './utils/easing';

--- a/src/utils/drag.ts
+++ b/src/utils/drag.ts
@@ -2,12 +2,15 @@ export type Position = { x: number; y: number };
 export type TouchMoves = { position: Position; ts: number }[];
 
 export const registerMove = (lastMoves: TouchMoves, position: Position) => {
-  return [{ position, ts: Date.now() }, ...lastMoves].slice(0, 2);
+  return [{ position, ts: Date.now() }, ...lastMoves].slice(0, 5).filter((move) => move.ts > Date.now() - 250);
 };
 
 export const getVelocity = (lastMoves: TouchMoves) => {
-  const distance = lastMoves[0]?.position.x - lastMoves[1]?.position.x;
-  const time = lastMoves[0]?.ts - lastMoves[1]?.ts;
+  if (lastMoves.length < 2) return 0;
 
-  return distance * (time / 32);
+  const distance = lastMoves[0].position.x - lastMoves[lastMoves.length - 1].position.x;
+  const time = lastMoves[0].ts - lastMoves[lastMoves.length - 1].ts;
+
+  // velocity is movement per millisecond
+  return distance / time;
 };

--- a/src/utils/easing.ts
+++ b/src/utils/easing.ts
@@ -6,6 +6,17 @@ export const easeOut: AnimationFn = (currentTime, startValue, changeInValue, dur
   return changeInValue * (currentTime * currentTime * currentTime + 1) + startValue;
 };
 
+export const easeOutQuartic: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
+  currentTime /= duration;
+  currentTime--;
+  return -changeInValue * (currentTime * currentTime * currentTime * currentTime - 1) + startValue;
+};
+
+export const easeInOutCubic: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
+  currentTime /= duration;
+  return changeInValue * (currentTime < 0.5 ? 4 * currentTime * currentTime * currentTime : 1 - Math.pow(-2 * currentTime + 2, 3) / 2) + startValue;
+}
+
 export const easeInOut: AnimationFn = (currentTime, startValue, changeInValue, duration) => {
   currentTime /= duration / 2;
   if (currentTime < 1) {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,1 +1,5 @@
 export const getCircularIndex = (index: number, length: number) => ((index % length) + length) % length;
+
+export function interpolate(a: number, b: number, t: number): number {
+  return a * (1 - t) + b * t;
+}


### PR DESCRIPTION
This is an update to #54 to make the transition between the velocity animation and snapping animation direct.

Instead of interpolating the velocity with the snapping target, which causes a "jump" or rubberband feel when snapping, this solution aims to go from the velocity animation to the snapping animation with the same speed.

To achieve this, the snapping animation kicks in when the velocity drops below 10. This is just an arbitrary value and can be tweaked further. Since we know that the last velocity was near 10, we can calculate the duration of the ease-out transition to the target position by multiplying the change in pixels by 5. This is also an arbitrary value that seems to work well in different swipe speed tests maintaining the velocity in the first frames.