### PR TITLE
Feat / Swipe optimization 7

### DIFF
--- a/docs/docs/configuration/render-tile.md
+++ b/docs/docs/configuration/render-tile.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 # Render tile
 
 The `renderTile` render function is called for each tile rendered in the slider.
-Use the `props.item` property to access the data off the current item in the `TileSlider#items` array. 
+Use the `props.item` property to access the data off the current item in the `TileSlider#items` array.
 
 For the best performance, it's advised to keep the tile component simple.
 
@@ -17,7 +17,7 @@ The `renderTile` prop is required.
 import type { RenderTile } from './TileSlider';
 
 const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
-  <div className={`exampleTile ${!isVisible ? 'outOfView' : ''}`}>
+  <div className={'exampleTile'}>
     <img src={item.image} alt={item.title} />
   </div>
 );
@@ -28,10 +28,9 @@ const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
 The `renderTile` function receives the following props:
 
 | Name      | Type                                     | Description                                           |
-|-----------|------------------------------------------|-------------------------------------------------------|
+| --------- | ---------------------------------------- | ----------------------------------------------------- |
 | item      | `T`                                      | The item rendered for this tile                       |
 | itemIndex | `number`                                 | The index used to address the item in the items array |
 | index     | `number`                                 | The index relative to the current rendered index      |
 | isVisible | `boolean`                                | `true` when the tile is visible (inside viewport)     |
 | slide     | `(direction: 'left' \| 'right') => void` | Call this function to slide left or right             |
-

--- a/docs/docs/examples-advanced/out-of-boundary-tiles.mdx
+++ b/docs/docs/examples-advanced/out-of-boundary-tiles.mdx
@@ -8,12 +8,11 @@ Show tiles that are out of the boundary of the TileSlider container.
 
 ## Example
 
-
 import { TileSlider } from '../../../src';
 import { items, renderLeftControl, renderRightControl, renderTile } from '../helpers';
 import '../../../src/style.css';
 
-<div className="sliderContainer">
+<div className="sliderContainer sliderContainerFade">
   <TileSlider
     className="slider showOutOfView"
     items={items}
@@ -45,7 +44,7 @@ import { TileSlider } from '@videodock/tile-slider';
 
 const Slider = () => {
   return (
-    <div className="sliderContainer">
+    <div className="sliderContainer fade">
       <TileSlider
         className="showOutOfView"
         tilesToShow={3}

--- a/docs/docs/examples/basic.mdx
+++ b/docs/docs/examples/basic.mdx
@@ -4,14 +4,19 @@ sidebar_position: 1
 
 # Basic example
 
-
 ## Example
 
 import { TileSlider } from '../../../src';
 import { items, renderLeftControl, renderRightControl, renderTile } from '../helpers';
 import '../../../src/style.css';
 
-<TileSlider tilesToShow={3} renderTile={renderTile} items={items} renderRightControl={renderRightControl} renderLeftControl={renderLeftControl} />
+<TileSlider
+  tilesToShow={3}
+  renderTile={renderTile}
+  items={items}
+  renderRightControl={renderRightControl}
+  renderLeftControl={renderLeftControl}
+/>
 
 ## Code
 
@@ -30,7 +35,7 @@ const items: Tile[] = Array.from({ length: 10 }, (_, index) => ({
 }));
 
 const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
-  <div className={`exampleTile ${!isVisible ? 'outOfView' : ''}`}>
+  <div className={'exampleTile'}>
     <img src={item.image} alt={item.title} />
   </div>
 );

--- a/docs/docs/examples/no-pages.mdx
+++ b/docs/docs/examples/no-pages.mdx
@@ -4,14 +4,19 @@ sidebar_position: 6
 
 # No pages
 
-
 ## Example
 
 import { TileSlider } from '../../../src';
 import { items, renderLeftControl, renderRightControl, renderTile } from '../helpers';
 import '../../../src/style.css';
 
-<TileSlider tilesToShow={3} renderTile={renderTile} items={items.slice(0, 3)} renderRightControl={renderRightControl} renderLeftControl={renderLeftControl} />
+<TileSlider
+  tilesToShow={3}
+  renderTile={renderTile}
+  items={items.slice(0, 3)}
+  renderRightControl={renderRightControl}
+  renderLeftControl={renderLeftControl}
+/>
 
 ## Code
 
@@ -30,7 +35,7 @@ const items: Tile[] = Array.from({ length: 10 }, (_, index) => ({
 }));
 
 const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
-  <div className={`exampleTile ${!isVisible ? 'outOfView' : ''}`}>
+  <div className={'exampleTile'}>
     <img src={item.image} alt={item.title} />
   </div>
 );

--- a/docs/docs/helpers.tsx
+++ b/docs/docs/helpers.tsx
@@ -34,13 +34,13 @@ export const IconRight = () => (
 );
 
 export const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
-  <div className={`exampleTile ${!isVisible ? 'outOfView' : ''}`}>
+  <div className={'exampleTile'}>
     <img src={item.image} alt={item.title} />
   </div>
 );
 
 export const renderTileWithTitle: RenderTile<Tile> = ({ item, isVisible }) => (
-  <div className={`exampleTile ${!isVisible ? 'outOfView' : ''}`}>
+  <div className={'exampleTile'}>
     <img src={item.image} alt={item.title} />
     <div>{item.title}</div>
   </div>
@@ -130,9 +130,9 @@ export const WithDynamicPropsExample = () => {
         renderLeftControl={renderLeftControl}
       />
       <label>Tiles to show: </label>
-      <button onClick={() => setState({ tilesToShow: state.tilesToShow - 1})}>-</button>
+      <button onClick={() => setState({ tilesToShow: state.tilesToShow - 1 })}>-</button>
       <input value={state.tilesToShow} style={{ width: 40, textAlign: 'center' }} />
-      <button onClick={() => setState({ tilesToShow: state.tilesToShow + 1})}>+</button>
+      <button onClick={() => setState({ tilesToShow: state.tilesToShow + 1 })}>+</button>
     </>
   );
 };

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -48,10 +48,6 @@
   -webkit-touch-callout: none;
 }
 
-.outOfView {
-  opacity: 0.5;
-}
-
 .control {
   display: flex;
   align-items: center;
@@ -103,6 +99,22 @@
   overflow: hidden;
   margin: 32px 0;
   padding: 0 56px;
+}
+
+.sliderContainerFade {
+  position: relative;
+}
+
+.sliderContainerFade::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(to right, var(--ifm-background-color) 0, rgba(0, 0, 0, 0) 56px,  rgba(0, 0, 0, 0) calc(100% - 56px), var(--ifm-background-color) 100%);
+  opacity: 0.65;
+  pointer-events: none;
+  content: '';
 }
 
 .showOutOfView {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@videodock/tile-slider",
-  "version": "2.0.0-rc.6",
+  "version": "2.0.0-rc.7",
   "repository": {
     "url": "https://github.com/Videodock/tile-slider"
   },

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -248,7 +248,7 @@ export const TileSlider = <T,>({
     // Swipe to prev/next (consider a velocity between -8 and 8 to be a swipe)
     // A velocity of 8 is little more than a gentle swipe
     if (Math.abs(startVelocity) < 8) {
-      return handleSnapping(calculateIndex() + (startVelocity > 0 ? -1 : 1), easeOutQuartic, SLIDE_SNAPPING_DAMPING);
+      return handleSnapping(calculateIndex(), easeOutQuartic, SLIDE_SNAPPING_DAMPING);
     }
 
     // animation duration based on the velocity


### PR DESCRIPTION
## Feat / Swipe optimization 7
- Removed the extra tile snap whenever a small swipe is initiated. It felt unnatural that the slider can move 2 tiles, when the thumb lets go halfway 1 tile.
- Replaced the Out of view example with a fade solution. This, of course, is a bit more opinionated, but I find a subtle fade much more stable than switching the opacity during a slide, drag or swipe. But let me know your thoughts!

https://github.com/Videodock/tile-slider/assets/61868085/d33a888d-73d5-46b9-a70c-acd520a0577c


