### PR TITLE
Feat /  Always call the render left/right control functions

### DIFF
--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -107,10 +107,9 @@ export const TileSlider = <T,>({
     toIndex: 0,
     sliding: false,
     page: 0,
-    hasSlideBefore: false,
   });
 
-  const leftControlDisabled = (cycleMode === 'stop' && state.index === 0) || !state.hasSlideBefore;
+  const leftControlDisabled = cycleMode === 'stop' && state.index === 0;
   const rightControlDisabled = cycleMode === 'stop' && state.index === items.length - tilesToShow;
 
   const dynamicStepCount = pageStep === 'page' ? tilesToShow : 1;
@@ -176,7 +175,7 @@ export const TileSlider = <T,>({
     const page = Math.floor(getCircularIndex(index, items.length) / tilesToShow);
 
     if (!animated) {
-      setState((state) => ({ ...state, index, page, hasSlideBefore: true, sliding: false }));
+      setState((state) => ({ ...state, index, page, sliding: false }));
       frameRef.current.style.transform = `translateX(${relativeToPosition}%)`;
       onSlideEnd?.({
         index: index,

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -110,8 +110,6 @@ export const TileSlider = <T,>({
     hasSlideBefore: false,
   });
 
-  const showLeftControl: boolean = needControls && !(cycleMode === 'stop' && state.index === 0);
-  const showRightControl: boolean = needControls && !(cycleMode === 'stop' && state.index === items.length - tilesToShow);
   const leftControlDisabled = (cycleMode === 'stop' && state.index === 0) || !state.hasSlideBefore;
   const rightControlDisabled = cycleMode === 'stop' && state.index === items.length - tilesToShow;
 
@@ -540,29 +538,31 @@ export const TileSlider = <T,>({
     return Array.from({ length: totalTiles }, (_, index) => renderTileContainer(startIndex + index));
   };
 
+  const renderLeftControlWrapper = () => {
+    const content = renderLeftControl?.({
+      onClick: () => slide('left'),
+      disabled: leftControlDisabled,
+    });
+    return content && <div className="TileSlider-leftControl">{content}</div>;
+  };
+
+  const renderRightControlWrapper = () => {
+    const content = renderRightControl?.({
+      onClick: () => slide('right'),
+      disabled: rightControlDisabled,
+    });
+    return content && <div className="TileSlider-rightControl">{content}</div>;
+  };
+
   return (
     <div className={clx('TileSlider', className)}>
-      {showLeftControl && !!renderLeftControl && (
-        <div className="TileSlider-leftControl">
-          {renderLeftControl({
-            onClick: () => slide('left'),
-            disabled: leftControlDisabled,
-          })}
-        </div>
-      )}
+      {renderLeftControlWrapper()}
       <div className="TileSlider-gestures" style={{ marginLeft: -(spacing / 2), marginRight: -(spacing / 2) }} ref={gesturesRef}>
         <ul className="TileSlider-list" ref={frameRef} style={{ left: `calc(${listOffset}%)` }}>
           {renderTiles()}
         </ul>
       </div>
-      {showRightControl && !!renderRightControl && (
-        <div className="TileSlider-rightControl">
-          {renderRightControl({
-            onClick: () => slide('right'),
-            disabled: rightControlDisabled,
-          })}
-        </div>
-      )}
+      {renderRightControlWrapper()}
       {renderPagination?.({
         index: state.index,
         itemIndex: getCircularIndex(state.index, items.length),

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -99,7 +99,6 @@ export const TileSlider = <T,>({
   const responsiveTileWidth = 100 / tilesToShow;
   const isMultiPage: boolean = items.length > tilesToShow;
   const pages = Math.ceil(items.length / tilesToShow);
-  const needControls: boolean = showControls && isMultiPage;
 
   const [state, setState] = useState({
     index: 0,


### PR DESCRIPTION
For accessibility reasons, it is better to always call the render (left/right) controls function and leave the implementation details to the developer. With this change, it's the developer's responsibility to hide or disable the control based on the `disabled` argument.

When the control function returns a falsy value, the control wrapper won't get rendered. Preventing an unneeded `<div />` wrapper.

⚠️ I removed the `hasSlideBefore` state, which always evaluates to `false`, causing the left control to be disabled when you have reached the end of the slider (when using cycle-mode `stop`). I did some (mobile) swipe tests with `console.log` on the state, but I have never seen this being evaluated as `true`. I don't know which problem this variable tries to solve. Please be aware of this while reviewing.

Ticket: https://videodock.atlassian.net/browse/DDSB-4967
