### PR TITLE
Feat / add support for cycle mode restart

### DIFF
--- a/docs/docs/examples/cycle-mode-restart.mdx
+++ b/docs/docs/examples/cycle-mode-restart.mdx
@@ -1,0 +1,78 @@
+---
+sidebar_position: 8
+---
+
+# Cycle Mode Restart
+
+## Example
+
+import { TileSlider, CYCLE_MODE_RESTART } from '../../../src';
+import { items, renderLeftControl, renderRightControl, renderTile } from '../helpers';
+import '../../../src/style.css';
+
+<h3>Pagination</h3>
+<TileSlider
+  tilesToShow={3}
+  cycleMode={CYCLE_MODE_RESTART}
+  renderTile={renderTile}
+  items={items.slice(0, 5)}
+  renderRightControl={renderRightControl}
+  renderLeftControl={renderLeftControl}
+/>
+<h3>No pagination</h3>
+<TileSlider
+  tilesToShow={3}
+  cycleMode={CYCLE_MODE_RESTART}
+  renderTile={renderTile}
+  items={items.slice(0, 2)}
+  renderRightControl={renderRightControl}
+  renderLeftControl={renderLeftControl}
+/>
+
+## Code
+
+```tsx
+import { TileSlider, type RenderTile, type RenderControl, CYCLE_MODE_STOP } from '@videodock/tile-slider';
+
+type Tile = {
+  title: string;
+  image: string;
+};
+
+// create example data set with 10 tiles
+const items: Tile[] = Array.from({ length: 10 }, (_, index) => ({
+  title: `Tile ${index}`,
+  image: `/img/${index}.jpg`,
+}));
+
+const renderTile: RenderTile<Tile> = ({ item, isVisible }) => (
+  <div className={'exampleTile'}>
+    <img src={item.image} alt={item.title} />
+  </div>
+);
+
+const renderLeftControl: RenderControl = ({ onClick }) => (
+  <button className="control" onClick={onClick}>
+    <IconLeft />
+  </button>
+);
+
+const renderRightControl: RenderControl = ({ onClick }) => (
+  <button className="control" onClick={onClick}>
+    <IconRight />
+  </button>
+);
+
+const Slider = () => {
+  return (
+    <TileSlider
+      cycleMode={CYCLE_MODE_STOP}
+      tilesToShow={3}
+      renderTile={renderTile}
+      items={items}
+      renderRightControl={renderRightControl}
+      renderLeftControl={renderLeftControl}
+    />
+  );
+};
+```

--- a/docs/docs/examples/cycle-mode-restart.mdx
+++ b/docs/docs/examples/cycle-mode-restart.mdx
@@ -66,7 +66,7 @@ const renderRightControl: RenderControl = ({ onClick }) => (
 const Slider = () => {
   return (
     <TileSlider
-      cycleMode={CYCLE_MODE_STOP}
+      cycleMode={CYCLE_MODE_RESTART}
       tilesToShow={3}
       renderTile={renderTile}
       items={items}

--- a/src/TileSlider.tsx
+++ b/src/TileSlider.tsx
@@ -6,8 +6,11 @@ import { getCircularIndex } from './utils/math';
 import { clx } from './utils/clx';
 import { getVelocity, Position, registerMove, TouchMoves } from './utils/drag';
 
+// only render the given items once and stop sliding when reaching the beginning or end
 export const CYCLE_MODE_STOP = 'stop';
+// endless render items, but align to the first and last item when using the slide left/right controls
 export const CYCLE_MODE_RESTART = 'restart';
+// endless render items
 export const CYCLE_MODE_ENDLESS = 'endless';
 
 export const PREFERS_REDUCED_MOTION = typeof window !== 'undefined' ? !window.matchMedia('(prefers-reduced-motion)').matches : false;
@@ -263,7 +266,7 @@ export const TileSlider = <T,>({
    * tile.
    */
   const handleVelocity = useEventCallback(() => {
-    let startVelocity = sliderDataRef.current.velocity * 16;
+    const startVelocity = sliderDataRef.current.velocity * 16;
 
     // snap back to the current tile when the velocity is near zero
     if (Math.abs(startVelocity) < 1) {
@@ -433,10 +436,23 @@ export const TileSlider = <T,>({
   const slide = useCallback(
     (direction: Direction) => {
       const directionFactor = direction === 'right' ? 1 : -1;
+      let slideStepCount = stepCount;
 
-      slideToIndex(state.index + stepCount * directionFactor);
+      if (cycleMode === CYCLE_MODE_RESTART) {
+        const itemIndex = getCircularIndex(state.index, items.length);
+        const diffToLast = items.length - tilesToShow - itemIndex;
+        const diffToFirst = itemIndex;
+
+        // slide to the first/last item when exceeding
+        if (direction === 'right' && diffToLast !== 0) slideStepCount = Math.min(diffToLast, slideStepCount);
+        if (direction === 'left' && diffToFirst !== 0) slideStepCount = Math.min(diffToFirst, slideStepCount);
+      }
+
+      const toIndex = state.index + slideStepCount * directionFactor;
+
+      slideToIndex(toIndex);
     },
-    [slideToIndex, state.index, stepCount],
+    [cycleMode, items.length, slideToIndex, state.index, stepCount, tilesToShow],
   );
 
   useImperativeHandle(sliderRef, () => {


### PR DESCRIPTION
In #125 we've fixed cycle mode stop. This PR adds support for the last cycle mode, restart. Using this, the slider acts almost the same as the endless cycle mode, but when sliding, it indicates the beginning or end of the list by snapping to the first or last item. This also means that it will not drift when sliding, causing the first slide not to show at the beginning anymore.

I also added an example page for this cycle mode. 